### PR TITLE
Fix typos in README ('gradent' -> 'gradient')

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Blend mode translation is also included with this Compass extension.
 ## Install the Ruby Gem.
 
   ```
-  gem install compass-photoshop-gradent-overlay
+  gem install compass-photoshop-gradient-overlay
   ```
 
 ### Install into an existing project:
@@ -15,37 +15,37 @@ Blend mode translation is also included with this Compass extension.
 Edit the project configuration file (`config.rb`) and add:
 
   ```ruby
-  require 'compass-photoshop-gradent-overlay'
+  require 'compass-photoshop-gradient-overlay'
   ```
 
 Then run this command from the root of your project:
 
   ```
-  compass install compass-photoshop-gradent-overlay
+  compass install compass-photoshop-gradient-overlay
   ```
 
 ### When creating a new project:
 
   ```
-  compass create my_project -r compass-photoshop-gradent-overlay --using compass-photoshop-gradent-overlay
+  compass create my_project -r compass-photoshop-gradient-overlay --using compass-photoshop-gradient-overlay
   ```
 
 By default, the extension doesn't add any files to your project. An example scss and html file can be imported by installing the "example" pattern:
 
   ```
-  compass install compass-photoshop-gradent-overlay/example
+  compass install compass-photoshop-gradient-overlay/example
   ```
 
 # Usage
 
   ```scss
-  @import 'photoshop-gradent-overlay';
+  @import 'photoshop-gradient-overlay';
   ```
 
 ## Function Reference
 
   ```scss
-  photoshop-gradent-overlay( $bg-color, [$blend], [$opacity], [$angle], [$scale], [$gradient-colors], [$gradient-stops] )
+  photoshop-gradient-overlay( $bg-color, [$blend], [$opacity], [$angle], [$scale], [$gradient-colors], [$gradient-stops] )
   ```
 
 ### Function Parameters


### PR DESCRIPTION
Noticed some typos in the README
