### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ By default, the extension doesn't add any files to your project. An example scss
 
 `$bg-color` (required, Color) The background color of the element.
 
-`$blend` (optional, String) The blend mode used to mix the gradient and the backgorund-color. Defaults to "normal" (no blending).
+`$blend` (optional, String) The blend mode used to mix the gradient and the background-color. Defaults to "normal" (no blending).
 
 `$opacity` (optional, Percentage) The strength of the overlay. Accepts values between 0% & 100%. Defaults to 100%.
 


### PR DESCRIPTION
@timhettler, I've corrected a typographical error in the documentation of the [compass-photoshop-gradient-overlay](https://github.com/timhettler/compass-photoshop-gradient-overlay) project. Specifically, I've changed backgorund to background. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
